### PR TITLE
Sticky header

### DIFF
--- a/index.styl
+++ b/index.styl
@@ -26,7 +26,8 @@ table.opcode
     font-family: 'Ubuntu Mono', monospace
 
 
-table.opcode 
+table.opcode
+    position: relative
     border-collapse: collapse
     table-layout: fixed
     width: 100%
@@ -49,7 +50,6 @@ table.opcode
         >td
             text-align: center
             padding: 0
-         
     thead
         width: 100%
 
@@ -57,11 +57,21 @@ table.opcode
             &:nth-of-type(odd)>th
                 background-color: lightgrey
 
+            &>th:not(:first-child)
+                position: sticky
+                top: -1px
+                z-index: 1
+
     tbody>tr
         &:nth-of-type(even)>th
             background-color: lightgrey
         &:nth-of-type(odd)>th
-            background-color: rgb(245, 245, 245)         
+            background-color: rgb(245, 245, 245)
+
+        &>th
+            position: sticky
+            left: -1px
+            z-index: 1
 
 :root {
     background-color: snow
@@ -88,7 +98,7 @@ h1
     width: 80%
     left: 10%
     height: 100%;
-    
+
     @media screen and (min-width: 30em) and (max-width: 48em) {
         width: 24em
         left: 50%
@@ -98,7 +108,7 @@ h1
     @media screen and (min-width: 48em) {
         left: 25%
         width: 50%
-    
+
     }
 
     @media screen and (min-height: 18em) and (max-height: 30em) {
@@ -109,7 +119,7 @@ h1
 
     @media screen and (min-height: 30em) {
         top: 20%
-        height: 60%    
+        height: 60%
     }
 
     background-color: snow
@@ -140,12 +150,12 @@ td.opcode
         width: 0.7em
         background-color: slategray
         content: ""
-    
+
     pre
         display inline
     > div
         padding: 0.8em
-        
+
     &.lsm
         &.x8
             opcode-coloring(lsm-8-color)
@@ -160,7 +170,7 @@ td.opcode
 
     &.x8.rsb
         opcode-coloring(rsb-8-color)
-        
+
     &.control
         &.misc
             opcode-coloring(control-misc-color)
@@ -176,7 +186,7 @@ td.opcode:not(.unused):hover
 
 td.opcode.hidden
     visibility: hidden
-  
+
 code
     background-color: rgb(230, 230, 230)
     font-family: 'Ubuntu Mono', monospace
@@ -207,7 +217,7 @@ dl.groups, ul.groups
                 color: lsm-8-color
             &.x16::before
                 color: lsm-16-color
-        
+
         &.alu
             &.x8::before
                 color: alu-8-color
@@ -216,7 +226,7 @@ dl.groups, ul.groups
 
         &.x8.rsb::before
             color: rsb-8-color
-            
+
         &.control
             &.misc::before
                 color: control-br-color
@@ -242,20 +252,20 @@ a
     justify-self: center
     text-align: center
     margin: 0.5em
-  
+
 .data-column
     justify-self: start
     grid-area: 2 / 1
     margin: 0.5em
-  
+
 .timing-column
     justify-self: end
     grid-area: 2 / 2
     margin: 0.5em
-  
+
 .flag-table
     caption
-        margin-top: 1em 
+        margin-top: 1em
     th
         text-align: left
         margin-right: 0.5em


### PR DESCRIPTION
Hello,

I've added sticky for `th` elements, it looks like this.

![Screenshot 2021-02-16 at 15 02 19](https://user-images.githubusercontent.com/660716/108073807-c17c7180-7068-11eb-8c0c-458564a7904e.png)

Tell me what you think.

The bottom (or the right) borders of sticky items are not visible because of `border-collapse: collapse;`...
